### PR TITLE
Update Answers.Droid initializer to match Answers.Droid and Crashlytics

### DIFF
--- a/Sources/AnswersKit.Droid/Answers.cs
+++ b/Sources/AnswersKit.Droid/Answers.cs
@@ -218,12 +218,7 @@ namespace AnswersKit
             {
                 if (_initialized) return;
 
-                var native = (Bindings.AnswersKit.Answers)answers.ToNative();
-
-                Bindings.FabricSdk.Fabric.With(new Bindings.FabricSdk.Fabric.Builder(context)
-                    .Kits(native)
-                    .Debuggable(Fabric.Instance.Debug)
-                    .Build());
+                Fabric.Instance.Kits.Add(answers);
 
                 _initialized = true;
             }


### PR DESCRIPTION
current initializer calls Fabric.With which prevents any other kit being used. see issue #52 